### PR TITLE
Add Crc inverse functions and unhasher class

### DIFF
--- a/src/MajiroLib/Script/Crc.cs
+++ b/src/MajiroLib/Script/Crc.cs
@@ -6,9 +6,10 @@ namespace Majiro.Script {
 	public static class Crc {
 
 		private static readonly uint[] Crc32Table = Enumerable.Range(0, 256).Select(Calculate32).ToArray();
+		private static readonly byte[] Crc32Index = Enumerable.Range(0, 256).Select(CalculateInverse32).ToArray();
 		private static readonly byte[] CryptKey32 = Crc32Table.SelectMany(BitConverter.GetBytes).ToArray();
 
-		private static readonly long[] Crc64Table = Enumerable.Range(0, 256).Select(Calculate64).ToArray();
+		private static readonly ulong[] Crc64Table = Enumerable.Range(0, 256).Select(Calculate64).ToArray();
 		private static readonly byte[] CryptKey64 = Crc64Table.SelectMany(BitConverter.GetBytes).ToArray();
 
 		public static uint Calculate32(int seed) {
@@ -19,41 +20,64 @@ namespace Majiro.Script {
 			}
 			return value;
 		}
-		public static long Calculate64(int seed) {
-			const ulong poly = 0x85E1C3D753D46D27;
+		public static ulong Calculate64(int seed) {
+			// Assembly implementation uses poly: 0x85E1C3D753D46D27, and bitshifts after XOR with poly.
+			// Behavior is identical to normal CRC-64 implementation with common poly: 0x42F0E1EBA9EA3693.
+			//  (except the forward polynomial is used for a reverse implementation)
+			const ulong poly = 0x42F0E1EBA9EA3693;
 			ulong value = (ulong)seed;
 			for(int i = 0; i < 8; i++) {
-				value = (value & 1) != 0 ? (value ^ poly) >> 1 : value >> 1;
+				value = (value & 1) != 0 ? (value >> 1) ^ poly : value >> 1;
 			}
-			return (long)value;
+			return value;
+		}
+
+		public static byte CalculateInverse32(int seed) {
+			uint msbyte = (uint)seed;
+			for(int i = 0; i < 256; i++) {
+				if((Calculate32(i) >> 24) == msbyte)
+					return (byte) i;
+			}
+			throw new ArgumentException($"Most significant byte 0x{msbyte:x2} not in {nameof(Crc32Table)}");
 		}
 
 		public static void Crypt32(byte[] bytes, int keyOffset = 0) {
 			for(int i = 0; i < bytes.Length; i++) {
-				bytes[i] ^= CryptKey32[keyOffset++ & 0x3FF];
+				bytes[i] ^= CryptKey32[keyOffset++ & 0x3FF]; // (bitwise: % 1024)
 			}
 		}
 
 		public static void Crypt64(byte[] bytes, int keyOffset = 0) {
 			for(int i = 0; i < bytes.Length; i++) {
-				bytes[i] ^= CryptKey64[keyOffset++ & 0x7FF];
+				bytes[i] ^= CryptKey64[keyOffset++ & 0x7FF]; // (bitwise: % 1024)
 			}
 		}
 
-		public static uint Hash32(string s) => Hash32(Helpers.ShiftJis.GetBytes(s));
+		public static uint Hash32(string s, uint init = 0u) => Hash32(Helpers.ShiftJis.GetBytes(s), init);
 
-		public static uint Hash32(byte[] bytes) {
-			uint result = 0xFFFFFFFF;
+		public static uint Hash32(byte[] bytes, uint init = 0u) {
+			uint result = ~init;
 			foreach(byte b in bytes) {
 				result = (result >> 8) ^ Crc32Table[(byte)(result ^ b)];
 			}
 			return ~result;
 		}
 
-		public static long Hash64(string s) => Hash64(Helpers.ShiftJis.GetBytes(s));
+		public static uint HashInverse32(string s, uint init) => HashInverse32(Helpers.ShiftJis.GetBytes(s), init);
 
-		public static long Hash64(byte[] bytes) {
-			long result = -1;
+		public static uint HashInverse32(byte[] bytes, uint init) {
+			uint result = ~init;
+			foreach(byte b in bytes.Reverse()) {
+				uint index = Crc32Index[result >> 24];
+				result = ((result ^ Crc32Table[index]) << 8) | (index ^ b);
+			}
+			return ~result;
+		}
+
+		public static ulong Hash64(string s, ulong init = 0ul) => Hash64(Helpers.ShiftJis.GetBytes(s), init);
+
+		public static ulong Hash64(byte[] bytes, ulong init = 0ul) {
+			ulong result = ~init;
 			foreach(byte b in bytes) {
 				result = (result >> 8) ^ Crc64Table[(byte)(result ^ b)];
 			}

--- a/src/MajiroLib/Script/CrcUnhasher.cs
+++ b/src/MajiroLib/Script/CrcUnhasher.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Majiro.Script {
+
+	public class CrcUnhasher : IEnumerator<string>, IEnumerable<string> {
+		public const string DefaultCharset = "abcdefghijklmnopqrstuvwxyz_0123456789";
+		private static readonly byte[] DefaultCharsetBytes = Helpers.ShiftJis.GetBytes(DefaultCharset);
+
+		private uint target = 0;
+		private string prefix = "";
+		private string postfix = "";
+		private string charset = DefaultCharset;
+		private int length = 0; // number of characters in the pattern
+		private uint init = 0; // crc of prefix
+		private uint expected = 0; // inverse crc of postfix with target as init value
+		private byte[] charsetBytes = DefaultCharsetBytes;
+		// levels[] tracks the current charset index of every element in the buffer.
+		// It's used to save time comparing actual chars, and makes incrementing easier.
+		private int[] levels = Array.Empty<int>();
+		private byte[] buffer = Array.Empty<byte>();
+		private string current = null;
+		private long combinations = 0; // number of tried combinations, this is only for vanity and not required
+		private bool finished = false; // not truly finished until current == null
+
+		public CrcUnhasher() { }
+
+		public long Combinations => combinations;
+		public bool IsFinished => current == null && finished;
+		public string Pattern => string.Concat(prefix, Helpers.ShiftJis.GetString(buffer), postfix);
+
+		public uint Target {
+			get => target;
+			set {
+				target = value;
+				expected = Crc.HashInverse32(postfix, value);
+				Reset();
+			}
+		}
+		public string Prefix {
+			get => prefix;
+			set {
+				prefix = value;
+				init = Crc.Hash32(value);
+				Reset();
+			}
+		}
+		public string Postfix {
+			get => postfix;
+			set {
+				postfix = value;
+				expected = Crc.HashInverse32(value, target);
+				Reset();
+			}
+		}
+		public string Charset {
+			get => charset;
+			set {
+				charset = value;
+				charsetBytes = Helpers.ShiftJis.GetBytes(value);
+				Reset();
+			}
+		}
+		public int Length {
+			get => length;
+			set {
+				length = value;
+				levels = new int[length];
+				buffer = new byte[length];
+				Reset();
+			}
+		}
+
+		public void Reset() {
+			// Prepare initial buffer states: Fill levels and buffer, with all 0 and charset[0]
+			for(int i = 0; i < length; i++) {
+				levels[i] = 0;
+				buffer[i] = charsetBytes[0];
+			}
+			current = null;
+			finished = false;
+		}
+
+		public bool MoveNext() {
+			if(finished) {
+				current = null;
+				return false;
+			}
+
+			// Check current pattern
+			uint result = Crc.Hash32(buffer, init);
+			if(result == expected) {
+				current = Pattern;
+
+				// Special handling: there is only ONE 4-byte combination to transform one accum A into another B
+				// We can give up the current first 4 bytes.
+				// This is only a minor optimization, since 4 ASCII bytes of depth is pretty fast to scan through.
+				// (when length == 4, this behaves the same as a break;)
+				// Next for(bufferIndex)-loop iteration will push out first 4 chars from any combination:
+				//  charset = "ABC"
+				//  [ACBA]AA -> [AAAA]BA
+				for(int i = 0; i < Math.Min(4, length); i++) {
+					levels[i] = charsetBytes.Length - 1;
+				}
+			}
+			else {
+				current = null;
+			}
+
+			// Change to next pattern
+			//  charset = "ABC"
+			//  AAAA -> BAAA -> CAAA -> ABAA -> BBAA -> CBAA -> ACAA ...
+			int bufferIndex;
+			for(bufferIndex = 0; bufferIndex < length; bufferIndex++) {
+				int charsetIndex = ++levels[bufferIndex]; // next character at current buffer index
+				if(charsetIndex != charsetBytes.Length) {
+					// Letter incremented, break and hash new pattern
+					buffer[bufferIndex] = charsetBytes[charsetIndex];
+					break;
+				}
+				else {
+					// Wrap letter back to charset[0], continue to next index
+					levels[bufferIndex] = 0;
+					buffer[bufferIndex] = charsetBytes[0];
+				}
+			}
+			combinations++;
+			finished = (bufferIndex >= length);
+			return true;
+		}
+
+		public string Current => current;
+		object IEnumerator.Current => current;
+
+		public IEnumerator<string> GetEnumerator() => this;
+		IEnumerator IEnumerable.GetEnumerator() => this;
+
+		void IDisposable.Dispose() { }
+	}
+}


### PR DESCRIPTION
Create additional utilities for working with CRC hashes, primarily aimed at reversing and unhashing CRC-32 operations performed on ASCII data. This includes methods to back-out initial values with `Crc.HashInverse32`, and to brute-force finding unhashed names with the class `CrcUnhasher`.

## class Crc

* Add `uint HashInverse32(string|bytes, uint)` for backing out the result of a Hash32 call (with known postfix data and CRC result)
    * Add `byte CalculateInverse32(int)` used to create the static `byte[] Crc32Index` table, needed by `HashInverse32`.
* Add optional `uint init = 0` parameters to all `Hash32` and `Hash64` functions.
* Update `Calculate64`/`Hash64` methods to use `ulong` for consistency.
* Refactor `Calculate64` to use standard reverse CRC-64 implementation (and add notes on the differences from asm). This implementation still produces identical results.

## class CrcUnhasher

* Add `CrcUnhasher` class that functions as an `IEnumerator<string>`/`IEnumerable<string>` for testing all possible permutations at a given length (surprisingly faster than expected)

### Example Usage

```cs
CrcUnhasher unhasher = new CrcUnhasher{
    Charset = "abcdefghijklmnopqrstuvwxyz_0123456789", //identical to CrcUnhasher.DefaultCharset
    Prefix  = "$",
    Postfix = "@MAJIRO_INTER",
    Target  = 0x959B0A16u,
};

for(unhasher.Length = 3; unhasher.Length <= 10; unhasher.Length++) {
    Console.WriteLine($"Pattern Depth: {unhasher.Length},  Combinations: {unhasher.Combinations}");
    foreach(string match in unhasher) {
        // all results are returned, including failed matches (null)
        // this allows easy control over when to kill the infinite cycle of permutations
        if(match != null) // match was successful
            Console.WriteLine(match);
    }
}
```

### Other Properties

```cs
string Pattern;  // returns the current pattern (even if the match failed)
bool IsFinished;  // returns true if all permutations have been tested for the given length
long Combinations;  // extra property that counts all permutations tested against
                    // (does not count permutations skipped by dump after identified collisions)
```

### Example Extension Methods

```cs
public static string ScanFor(this CrcUnhasher unhasher, long count) {
    while(count-- > 0 && unhasher.MoveNext() && unhasher.Current == null) ;
    return unhasher.Current;
}
public static string ScanForever(this CrcUnhasher unhasher) {
    while(unhasher.MoveNext() && unhasher.Current == null) ;
    return unhasher.Current;
}
public static bool TryScanFor(this CrcUnhasher unhasher, long count, out string result) {
    while(count-- > 0 && unhasher.MoveNext() && unhasher.Current == null) ;
    result = unhasher.Current;
    return result != null;
}
public static bool TryScanForever(this CrcUnhasher unhasher, out string result) {
    while(unhasher.MoveNext() && unhasher.Current == null) ;
    result = unhasher.Current;
    return result != null;
}
```