### PR TITLE
Overhaul CrcUnhasher class (part 1)

### DIFF
--- a/src/MajiroLib/Script/Crc.cs
+++ b/src/MajiroLib/Script/Crc.cs
@@ -62,6 +62,13 @@ namespace Majiro.Script {
 			}
 			return ~result;
 		}
+		public static uint Hash32At(byte[] bytes, int startIndex, int count, uint init = 0u) {
+			uint result = ~init;
+			for(int i = 0; i < count; i++) {
+				result = (result >> 8) ^ Crc32Table[(byte) (result ^ bytes[startIndex + i])];
+			}
+			return ~result;
+		}
 
 		public static uint HashInverse32(string s, uint init) => HashInverse32(Helpers.ShiftJis.GetBytes(s), init);
 
@@ -73,6 +80,14 @@ namespace Majiro.Script {
 			}
 			return ~result;
 		}
+		public static uint HashInverse32At(byte[] bytes, int startIndex, int count, uint init) {
+			uint result = ~init;
+			for(int i = 0; i < count; i++) {
+				uint index = Crc32Index[result >> 24];
+				result = ((result ^ Crc32Table[index]) << 8) | (index ^ bytes[startIndex + i]);
+			}
+			return ~result;
+		}
 
 		public static ulong Hash64(string s, ulong init = 0ul) => Hash64(Helpers.ShiftJis.GetBytes(s), init);
 
@@ -80,6 +95,13 @@ namespace Majiro.Script {
 			ulong result = ~init;
 			foreach(byte b in bytes) {
 				result = (result >> 8) ^ Crc64Table[(byte)(result ^ b)];
+			}
+			return ~result;
+		}
+		public static ulong Hash64At(byte[] bytes, int startIndex, int count, ulong init = 0ul) {
+			ulong result = ~init;
+			for(int i = 0; i < count; i++) {
+				result = (result >> 8) ^ Crc64Table[(byte) (result ^ bytes[startIndex + i])];
 			}
 			return ~result;
 		}

--- a/src/MajiroLib/Script/CrcUnhasher.cs
+++ b/src/MajiroLib/Script/CrcUnhasher.cs
@@ -1,70 +1,114 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
 
 namespace Majiro.Script {
 
 	public class CrcUnhasher : IEnumerator<string>, IEnumerable<string> {
-		public const string DefaultCharset = "abcdefghijklmnopqrstuvwxyz_0123456789";
-		private static readonly byte[] DefaultCharsetBytes = Helpers.ShiftJis.GetBytes(DefaultCharset);
+		public const string DefaultCharset = "a-z_0-9";
+		public const string DefaultCharsetExpanded = "abcdefghijklmnopqrstuvwxyz_0123456789";
+		private static readonly byte[] DefaultCharsetBytes = Helpers.ShiftJis.GetBytes(DefaultCharsetExpanded);
 
 		private uint target = 0;
-		private string prefix = "";
-		private string postfix = "";
-		private string charset = DefaultCharset;
+		private HashSet<uint> targetSet = null;
+		private string prefix = null;//"";
+		private string postfix = null;//"";
+		private bool depthFirst = false; // false: AAA->AAB->AAC->ABA, true: AAA->BAA->CAA->ABA
 		private int length = 0; // number of characters in the pattern
+		private string charsetRange = DefaultCharset;
+		private string charsetExpanded = DefaultCharsetExpanded;
+		private byte[] charsetBytes = DefaultCharsetBytes;
 		private uint init = 0; // crc of prefix
 		private uint expected = 0; // inverse crc of postfix with target as init value
-		private byte[] charsetBytes = DefaultCharsetBytes;
+		private HashSet<uint> expectedSet = null;
 		// levels[] tracks the current charset index of every element in the buffer.
 		// It's used to save time comparing actual chars, and makes incrementing easier.
 		private int[] levels = Array.Empty<int>();
 		private byte[] buffer = Array.Empty<byte>();
 		private string current = null;
+		private uint? result = null;
+		private bool finished = false; // this will be true the iteration BEFORE MoveNext returns true
 		private long combinations = 0; // number of tried combinations, this is only for vanity and not required
-		private bool finished = false; // not truly finished until current == null
 
 		public CrcUnhasher() { }
 
-		public long Combinations => combinations;
-		public bool IsFinished => current == null && finished;
-		public string Pattern => string.Concat(prefix, Helpers.ShiftJis.GetString(buffer), postfix);
+		// Configuration Properties:
 
+		/// <summary>Gets or sets the search order (false: AAA->AAB->AAC->ABA, true: AAA->BAA->CAA->ABA).</summary>
+		public bool DepthFirst {
+			get => depthFirst;
+			set {
+				depthFirst = value;
+				Reset();
+			}
+		}
+		/// <summary>Gets or sets the target CRC-32 hash value.</summary>
 		public uint Target {
 			get => target;
 			set {
 				target = value;
-				expected = Crc.HashInverse32(postfix, value);
+				UpdateExpected(true, false); // update both expected "single" and "set" values
 				Reset();
 			}
 		}
+		public HashSet<uint> TargetSet {
+			get => targetSet;
+			set {
+				targetSet = value;
+				UpdateExpected(false, true); // update expected "set" values only
+				Reset();
+			}
+		}
+		/// <summary>Gets or sets the constant unhashed prefix string (preserves null).</summary>
 		public string Prefix {
 			get => prefix;
 			set {
-				prefix = value;
-				init = Crc.Hash32(value);
+				prefix = value;// ?? throw new ArgumentNullException(nameof(Prefix));
+				UpdateInit(); // update initial value for CRC-32 input
 				Reset();
 			}
 		}
+		/// <summary>Gets or sets the constant unhashed postfix string (preserves null).</summary>
 		public string Postfix {
 			get => postfix;
 			set {
-				postfix = value;
-				expected = Crc.HashInverse32(value, target);
+				postfix = value;// ?? throw new ArgumentNullException(nameof(Postfix));
+				UpdateExpected(true, false); // update expected "single" values only
 				Reset();
 			}
 		}
+		/// <summary>Gets or sets the character set with range syntax (a-z_0-9).</summary>
 		public string Charset {
-			get => charset;
+			get => charsetRange;
 			set {
-				charset = value;
-				charsetBytes = Helpers.ShiftJis.GetBytes(value);
+				if(string.IsNullOrEmpty(value))
+					throw new ArgumentException("Empty: Charset is null or empty", nameof(Charset));
+				charsetExpanded = ParseCharsetRange(value, true); // duplicates are stripped by default
+				charsetRange = value;
+				charsetBytes = Helpers.ShiftJis.GetBytes(charsetExpanded);
 				Reset();
 			}
 		}
+		/// <summary>Gets or sets the character set without range syntax.</summary>
+		public string CharsetExpanded {
+			get => charsetExpanded;
+			set {
+				if(string.IsNullOrEmpty(value))
+					throw new ArgumentException("Empty: CharsetExpanded is null or empty", nameof(CharsetExpanded));
+				charsetRange = value.Replace("\\", "\\\\").Replace("-", "\\-"); // make sure this is a valid range
+				charsetExpanded = value;
+				charsetBytes = Helpers.ShiftJis.GetBytes(charsetExpanded);
+				Reset();
+			}
+		}
+		/// <summary>Gets or sets the pattern length to test against (0 is valid).</summary>
 		public int Length {
 			get => length;
 			set {
+				if(length < 0)
+					throw new ArgumentOutOfRangeException("InvalidLength: Length is less than zero");
 				length = value;
 				levels = new int[length];
 				buffer = new byte[length];
@@ -72,16 +116,89 @@ namespace Majiro.Script {
 			}
 		}
 
+		// Information and Resuming Properties:
+
+		/// <summary>Gets the total number of combinations tested against since this class's instantiation.</summary>
+		public long Combinations => combinations;
+		/// <summary>Gets if all permutations have been tested against for the current length.</summary>
+		public bool IsFinished => finished; // current == null && finished;
+		/// <summary>Returns total permutations for current charset.Length^length.</summary>
+		public BigInteger PermutationsBig => CountPermutationsBig(length, charsetBytes.Length);
+		/// <summary>Returns total permutations for current charset.Length^length (ulong.MaxValue on overflow).</summary>
+		public ulong Permutations => CountPermutations(length, charsetBytes.Length);
+		/// <summary>Gets the final CRC-32 result of the last check, including postfix (null if checks have not started).</summary>
+		public uint? Result => (result.HasValue ? Crc.Hash32(postfix??"", result.Value) : null);
+
+		/// <summary>Returns pattern of the last-checked match (null if checks have not started).</summary>
+		public string Pattern {
+			get {
+				if(current != null)
+					return current; // current == Pattern if it's a match, skip the extra steps
+				byte[] patternBuffer = (byte[])buffer.Clone();
+				bool notStarted = MoveBufferLast(patternBuffer, (int[])levels.Clone());
+				return (!notStarted ? Helpers.ShiftJis.GetString(patternBuffer) : null); // not run yet
+			}
+		}
+		/// <summary>Returns the Prefix+Pattern+Postfix of the last-checked match (null if checks have not started).</summary>
+		public string FullPattern {
+			get {
+				string pattern = Pattern;
+				return (pattern != null ? string.Concat(prefix??"", pattern, postfix??"") : null); // not run yet
+			}
+		}
+		/// <summary>Returns the pattern of the next check (null if checks have finished).</summary>
+		/// <remarks>
+		/// If last check matched, all remaining permutations for the current 4 chars are skipped (which may result in an unusual return).
+		/// </remarks>
+		public string PatternNext => (!finished ? Helpers.ShiftJis.GetString(buffer) : null);
+		/// <summary>Returns the Prefix+PatternNext+Postfix of the next check (null if checks have finished).</summary>
+		/// <remarks>
+		/// If last check matched, all remaining permutations for the current 4 chars are skipped (which may result in an unusual return).
+		/// </remarks>
+		public string FullPatternNext => (!finished ? string.Concat(prefix??"", PatternNext, postfix??"") : null);
+
+		/// <summary>Resumes current position in checks to pattern (null starts from beginning).</summary>
+		/// <remarks>If value is PatternNext, moveNext should be false. Otherwise specify moveNext if you want to skip the passed pattern.</remarks>
+		public void ResumePattern(string value, bool moveNext) {
+			Reset(); // Lazy: always reset first, to clean up and prepare everything
+			// Null handles as if resuming from beginning
+			if(value != null) {
+				byte[] newBuffer = Helpers.ShiftJis.GetBytes(value);
+				if(newBuffer.Length != length)
+					throw new ArgumentException("InvalidPattern: New Pattern length does not match current length");
+				for(int i = 0; i < length; i++) {
+					byte b = newBuffer[i];
+					int index = Array.IndexOf(charsetBytes, b);
+					if(index == -1)
+						throw new ArgumentException($"InvalidPattern: Character {(char) b} at index {i} not in charset");
+					levels[i] = index;
+					buffer[i] = b;
+				}
+			}
+			
+			if(moveNext) {
+				// Lazy: Move to next pattern internally (this also loads up the Current property)
+				MoveNext();
+				combinations--; // Lazy: decrement count since the goal was to skip this pattern
+			}
+		}
+
+
+		// IEnumerator Methods:
+
+		/// <summary>Resets pattern checks back to the beginning of the current length.</summary>
 		public void Reset() {
 			// Prepare initial buffer states: Fill levels and buffer, with all 0 and charset[0]
 			for(int i = 0; i < length; i++) {
 				levels[i] = 0;
 				buffer[i] = charsetBytes[0];
 			}
+			result = null;
 			current = null;
 			finished = false;
 		}
 
+		/// <summary>Checks the upcoming pattern in the buffer and moves to the next pattern.</summary>
 		public bool MoveNext() {
 			if(finished) {
 				current = null;
@@ -89,9 +206,10 @@ namespace Majiro.Script {
 			}
 
 			// Check current pattern
+			//uint result = Crc.Hash32(buffer, init);
 			uint result = Crc.Hash32(buffer, init);
-			if(result == expected) {
-				current = Pattern;
+			if(result == expected || (expectedSet?.Contains(result) ?? false)) {
+				current = Helpers.ShiftJis.GetString(buffer);
 
 				// Special handling: there is only ONE 4-byte combination to transform one accum A into another B
 				// We can give up the current first 4 bytes.
@@ -99,43 +217,221 @@ namespace Majiro.Script {
 				// (when length == 4, this behaves the same as a break;)
 				// Next for(bufferIndex)-loop iteration will push out first 4 chars from any combination:
 				//  charset = "ABC"
-				//  [ACBA]AA -> [AAAA]BA
-				for(int i = 0; i < Math.Min(4, length); i++) {
-					levels[i] = charsetBytes.Length - 1;
+				//  [ACBA]AA -> [AAAA]BA  (when depthFirst==true)
+				if(depthFirst) {
+					for(int i = 0; i < Math.Min(4, length); i++)
+						levels[i] = charsetBytes.Length - 1;
+				}
+				else {
+					for(int i = length - 1; i >= Math.Max(0, length - 4); i--)
+						levels[i] = charsetBytes.Length - 1;
 				}
 			}
 			else {
 				current = null;
 			}
+			this.result = result;
 
 			// Change to next pattern
-			//  charset = "ABC"
-			//  AAAA -> BAAA -> CAAA -> ABAA -> BBAA -> CBAA -> ACAA ...
-			int bufferIndex;
-			for(bufferIndex = 0; bufferIndex < length; bufferIndex++) {
-				int charsetIndex = ++levels[bufferIndex]; // next character at current buffer index
-				if(charsetIndex != charsetBytes.Length) {
-					// Letter incremented, break and hash new pattern
-					buffer[bufferIndex] = charsetBytes[charsetIndex];
-					break;
-				}
-				else {
-					// Wrap letter back to charset[0], continue to next index
-					levels[bufferIndex] = 0;
-					buffer[bufferIndex] = charsetBytes[0];
-				}
-			}
+			finished = MoveBufferNext(buffer, levels);
 			combinations++;
-			finished = (bufferIndex >= length);
 			return true;
 		}
 
+		// IEnumerator<> + IEnumerable<> Simple Methods and Properties:
+
+		/// <summary>Returns the current pattern of the last check (null if no match).</summary>
 		public string Current => current;
 		object IEnumerator.Current => current;
+		/// <summary>Returns the current Prefix+Current+Postfix of the last check (null if no match).</summary>
+		public string FullCurrent => (current != null ? string.Concat(prefix??"", current, postfix??"") : null);
 
 		public IEnumerator<string> GetEnumerator() => this;
 		IEnumerator IEnumerable.GetEnumerator() => this;
 
 		void IDisposable.Dispose() { }
+
+
+		// Private Update Methods:
+
+		/// <summary>Updates the init field based on changes to prefix.</summary>
+		private void UpdateInit() {
+			init = Crc.Hash32(prefix??"");
+		}
+		/// <summary>Updates the expected/expectedSet fields based on changes to target/targetSet/postfix.</summary>
+		private void UpdateExpected(bool single, bool multiple) {
+			if(single) {
+				expected = Crc.HashInverse32(postfix??"", target);
+			}
+			if(multiple) {
+				if(targetSet == null)
+					expectedSet = null;
+				else
+					expectedSet = new HashSet<uint>(targetSet.Select(t => Crc.HashInverse32(postfix??"", t)));
+			}
+		}
+
+		// Change to next (or last) pattern
+		//  charset = "ABC"
+		//  AAAA -> BAAA -> CAAA -> ABAA -> BBAA -> CBAA -> ACAA ... (example for depthFirst=true)
+		/// <summary>Changes buffer and levels arrays to next pattern (returns true on finished).</summary>
+		private bool MoveBufferNext(byte[] buffer, int[] levels) {
+			int bufferIndex;
+			if(depthFirst) {
+				for(bufferIndex = 0; bufferIndex < length; bufferIndex++) {
+					int charsetIndex = ++levels[bufferIndex]; // next character at current buffer index
+					if(charsetIndex != charsetBytes.Length) {
+						// Letter incremented, break with new pattern
+						buffer[bufferIndex] = charsetBytes[charsetIndex];
+						break;
+					}
+					else {
+						// Wrap letter back to charset[0], continue to next index
+						levels[bufferIndex] = 0;
+						buffer[bufferIndex] = charsetBytes[0];
+					}
+				}
+				return bufferIndex == length;
+			}
+			else {
+				for(bufferIndex = length - 1; bufferIndex >= 0; bufferIndex--) {
+					int charsetIndex = ++levels[bufferIndex]; // next character at current buffer index
+					if(charsetIndex != charsetBytes.Length) {
+						// Letter incremented, break with new pattern
+						buffer[bufferIndex] = charsetBytes[charsetIndex];
+						break;
+					}
+					else {
+						// Wrap letter back to charset[0], continue to previous index
+						levels[bufferIndex] = 0;
+						buffer[bufferIndex] = charsetBytes[0];
+					}
+				}
+				return bufferIndex == -1;
+			}
+		}
+		/// <summary>Changes buffer and levels arrays to last pattern (returns true on not started).</summary>
+		private bool MoveBufferLast(byte[] buffer, int[] levels) {
+			int bufferIndex;
+			if(depthFirst) {
+				for(bufferIndex = 0; bufferIndex < length; bufferIndex++) {
+					int charsetIndex = --levels[bufferIndex]; // next character at current buffer index
+					if(charsetIndex != -1) {
+						// Letter decremented, break with new pattern
+						buffer[bufferIndex] = charsetBytes[charsetIndex];
+						break;
+					}
+					else {
+						// Wrap letter back to charset[n-1], continue to next index
+						levels[bufferIndex] = charsetBytes.Length - 1;
+						buffer[bufferIndex] = charsetBytes[charsetBytes.Length - 1];
+					}
+				}
+				return bufferIndex == length;
+			}
+			else {
+				for(bufferIndex = length - 1; bufferIndex >= 0; bufferIndex--) {
+					int charsetIndex = --levels[bufferIndex]; // next character at current buffer index
+					if(charsetIndex != -1) {
+						// Letter decremented, break with new pattern
+						buffer[bufferIndex] = charsetBytes[charsetIndex];
+						break;
+					}
+					else {
+						// Wrap letter back to charset[n-1], continue to previous index
+						levels[bufferIndex] = charsetBytes.Length - 1;
+						buffer[bufferIndex] = charsetBytes[charsetBytes.Length - 1];
+					}
+				}
+				return bufferIndex == -1;
+			}
+		}
+
+
+		// Static Helper Methods:
+
+		/// <summary>Counts total permutations for a given charsetLength^length.</summary>
+		public static BigInteger CountPermutationsBig(int length, int charsetLength) {
+			return (length != 0 ? BigInteger.Pow(new BigInteger(charsetLength), length) : BigInteger.One);
+		}
+		/// <summary>Counts total permutations for a given charsetLength^length (ulong.MaxValue on overflow).</summary>
+		public static ulong CountPermutations(int length, int charsetLength) {
+			BigInteger count = CountPermutationsBig(length, charsetLength);
+			return (count < ulong.MaxValue ? (ulong)count : ulong.MaxValue);
+		}
+
+		/// <summary>Expands a range syntax character set (a-z_0-9) into its full form (includes error checking).</summary>
+		/// <remarks>Dash '-' and backslash '\' characters must be escaped with '\' to be used literally.</remarks>
+		public static string ParseCharsetRange(string pattern, bool stripDuplicates) {
+			List<char> charset = new List<char>();
+			bool lastRange = false;
+			for(int i = 0; i < pattern.Length; i++) {
+				char c = pattern[i];
+				switch(c) {
+				case '-': {  // Character range (functions off of previous literal character)
+					if(lastRange)
+						throw new ArgumentException($"InvalidRange: '-' after end of previous range, at index {i}");
+					else if(i == 0)
+						throw new ArgumentException($"Unescaped: '-' first character in charset, at index {i}");
+					else if(i+1 == pattern.Length)
+						throw new ArgumentException($"Unescaped: Trailing '-' in charset, at index {i}");
+
+					char start = pattern[i-1]; // before '-'
+					char end = pattern[++i]; // after '-'
+					if(end == '-') {
+						throw new ArgumentException($"Unescaped: '-' as range argument in charset, at index {i}");
+					}
+					else if(end == '\\') {
+						if(i+1 == pattern.Length)
+							throw new ArgumentException($"Trailing: '\\' escape in charset, at index {i}");
+						end = pattern[++i];
+					}
+					if(end < start)
+						throw new ArgumentException($"InvalidRange: [{start}-{end}], end char is less than start char, at index {i}");
+					// Add range: start char already added, start at +1
+					for(int cc = start + 1; cc <= end; cc++) {
+						charset.Add((char) cc);
+					}
+					lastRange = true;
+					break;
+				}
+				case '\\':  // Escape literal character
+					if(i+1 == pattern.Length)
+						throw new ArgumentException($"Trailing: '\\' escape in charset, at index {i}");
+					charset.Add(pattern[++i]);
+					lastRange = false;
+					break;
+				default:  // Literal character
+					charset.Add(c);
+					lastRange = false;
+					break;
+				}
+			}
+
+			// Error-check resulting charset:
+			// List of duplicates to include in error message (does not contain duplicate duplicates)
+			List<char> duplicates = (!stripDuplicates ? new List<char>() : null);
+			string origCharsetStr = (!stripDuplicates ? new string(charset.ToArray()) : null);
+			for(int i = 0; i < charset.Count; i++) {
+				bool first = true;
+				char c = charset[i];
+				for(int j = i+1; j < charset.Count; j++) {
+					if(c == charset[j]) {
+						if(!stripDuplicates && first) {
+							first = false;
+							duplicates.Add(c);
+						}
+						charset.RemoveAt(j);
+					}
+				}
+			}
+			if(!stripDuplicates && duplicates.Count != 0) {
+				string duplicatesStr = new string(duplicates.ToArray());
+				string duplicatesEsc = duplicatesStr.Replace("\\", "\\\\").Replace("\"", "\\\"");
+				throw new ArgumentException($"Duplicates: Found {duplicates.Count} duplicates in charset: \"{duplicatesEsc}\"");
+			}
+			// When origCharsetStr != null, we can use it here, as no duplicates were found when stripDuplicates = false
+			return origCharsetStr ?? new string(charset.ToArray());
+		}
 	}
 }


### PR DESCRIPTION
A LOT of changes to the `CrcUnhasher` class, although the existing functionality is near-identical to before.

## class CrcUnhasher Changes

### New Usages
```cs
CrcUnhasher unhasher = new CrcUnhasher{
    Charset = "a-z_0-9", //identical to CrcUnhasher.DefaultCharset
    Prefix  = "$",
    Postfix = "@MAJIRO_INTER",
    //Target  = 0x959B0A16u,
    TargetSet = new HashSet<uint>{0xF3755555u, 0xDEADBEAFu, 0x959B0A16u },
    DepthFirst = false, // default new search order
};

for (unhasher.Length = 3; unhasher.Length <= 10; unhasher.Length++) {
    Console.WriteLine($"Pattern Depth: {unhasher.Length},  Combinations: {unhasher.Combinations}");
    if (unhasher.Length == 3) unhasher.ResumePattern("abs", false); // next MoveNext() is abs
    if (unhasher.Length == 3) unhasher.ResumePattern("abr", true); // next MoveNext() is abs
    foreach (string match in unhasher) {
        if (match != null) { // match was successful
            Console.WriteLine(match);
            Console.WriteLine(unhasher.FullCurrent); // match including Prefix/Postfix
        }
    }
}
```

### Behavior Changes
* `Pattern`, `Current` (and by extension enumerating) returns the buffer pattern **ONLY**. No prefix/postfix added on. Use the `FullCurrent` and `FullPattern` properties to get the full value.
* `IsFinished` behavior now returns true regardless of matching on a final iteration. (The stated usage is now "have we finished", whether or not `MoveNext()` has been called to ask the same thing)
* Fixed Pattern property to return ACTUAL current pattern last-tested against, not the pattern ready to test next in the buffer.
* `Charset` property now asks for a range syntax. An exception will be raised for invalid syntax, such as unescaped `'-'` and `'\'`. Use `CharsetExpanded` to assign a literal charset without any special checks.
* By default, scan/search order now changes the last character most-frequently (`AAA->AAB->AAC->ABA`). Use the property `DepthFirst` = true, to go back to old behavior (`AAA->BAA->CAA->ABA`).

### Additions and non-breaking Changes
* A lot of JIT optimization may potentially be lost due to some code-separation, some of this can easily be reverted though.
* Added support for `HashSet<uint> TargetSet` property, which allows assigning a hash set of values to test against (as of now, normal `Target` property still exists and will be tested against regardless. This should be changed later).
* `Prefix` and `Postfix` property now support null, and have a default value of null. Properties will always return the same assigned value, so `""` or `null` for empty.
* Added `string PatternNext` + `string FullPatternNext` properties, which return the next pattern to be tested against (or `null`). This can be used with the method listed below)
* Added `void ResumePattern(string, bool)` method. This allows going back to your spot during unhashing without having to manually iterate through everything. This also means it's possible to jump around as needed, though calling `ResumePattern` is a bit expensive. When used with `string PatternNext`, the second argument (moveNext) should be false, as `PatternNext` is already the result of that. If you want to start checking ON the current pattern passed in, use false. Otherwise true to start at the next pattern.
* Add `ulong Permutations` and `BigInteger PermutationsBig` properties, to list the constant total number of Permutations for a given setup (charset.Length ^ length).
* Add `uint? Result` property, that returns the final hash result of the last check (including postfix, regardless of successful match). Returns `null` if checks have not started yet.
* Added summary docs to almost all functions and properties, to make understanding some of the wonkey behavior a bit easier to swallow.

## class Crc Changes
* Added `Hash`X`At` methods for `Hash32`, `HashInverse32` and `Hash64` in `Crc` class. Which allows Hashing only sections of a bytes array.