### PR TITLE
Fix CrcUnhasher expected hashes and collision dump

### DIFF
--- a/src/MajiroLib/Script/CrcUnhasher.cs
+++ b/src/MajiroLib/Script/CrcUnhasher.cs
@@ -49,7 +49,7 @@ namespace Majiro.Script {
 			get => target;
 			set {
 				target = value;
-				UpdateExpected(true, false); // update both expected "single" and "set" values
+				UpdateExpected(true, false); // update expected "single" values only
 				Reset();
 			}
 		}
@@ -75,7 +75,7 @@ namespace Majiro.Script {
 			get => postfix;
 			set {
 				postfix = value;// ?? throw new ArgumentNullException(nameof(Postfix));
-				UpdateExpected(true, false); // update expected "single" values only
+				UpdateExpected(true, true); // update both expected "single" and "set" values
 				Reset();
 			}
 		}

--- a/src/MajiroLib/Script/CrcUnhasher.cs
+++ b/src/MajiroLib/Script/CrcUnhasher.cs
@@ -218,13 +218,16 @@ namespace Majiro.Script {
 				// Next for(bufferIndex)-loop iteration will push out first 4 chars from any combination:
 				//  charset = "ABC"
 				//  [ACBA]AA -> [AAAA]BA  (when depthFirst==true)
-				if(depthFirst) {
-					for(int i = 0; i < Math.Min(4, length); i++)
-						levels[i] = charsetBytes.Length - 1;
-				}
-				else {
-					for(int i = length - 1; i >= Math.Max(0, length - 4); i--)
-						levels[i] = charsetBytes.Length - 1;
+				if(expectedSet == null) {
+					// we can't use this behavior when targetting multiple hashes
+					if(depthFirst) {
+						for(int i = 0; i < Math.Min(4, length); i++)
+							levels[i] = charsetBytes.Length - 1;
+					}
+					else {
+						for(int i = length - 1; i >= Math.Max(0, length - 4); i--)
+							levels[i] = charsetBytes.Length - 1;
+					}
 				}
 			}
 			else {


### PR DESCRIPTION
### Fix CrcUnhasher Postfix property expected values

* `Postfix` property was only updating expected **single** hash values, rendering `TargetSet` useless if set before `Postfix`.

### Disable CrcUnhasher collision dump 4 for multiple targets

* When hitting a collision, the current 4-character pattern would be skipped entirely due to no other possible collisions. This doesn't hold true when multiple hashes are being targeted, so the behavior has been disabled when `TargetSet` is non-null.