### PR TITLE
Move file reads out of Assert, Add using in MjProject Save/Load

### DIFF
--- a/src/MajiroLib/Project/MjProject.cs
+++ b/src/MajiroLib/Project/MjProject.cs
@@ -26,12 +26,12 @@ namespace Majiro.Project {
 		}
 
 		public void Save(string path) {
-			var writer = File.Open(path, FileMode.Create).NewTextWriter();
+			using var writer = File.Open(path, FileMode.Create).NewTextWriter();
 			new JsonSerializer { Formatting = Formatting.Indented }.Serialize(writer, this);
 		}
 
 		public static MjProject Load(string path) {
-			var reader = File.OpenText(path);
+			using var reader = File.OpenText(path);
 			return new JsonSerializer().Deserialize<MjProject>(new JsonTextReader(reader));
 		}
 	}

--- a/src/MajiroLib/Script/Disassembler.cs
+++ b/src/MajiroLib/Script/Disassembler.cs
@@ -92,7 +92,8 @@ namespace Majiro.Script {
 						// string data
 						ushort size = reader.ReadUInt16();
 						var bytes = reader.ReadBytes(size - 1);
-						Debug.Assert(reader.ReadByte() == 0);
+						byte nullTerminator = reader.ReadByte();
+						Debug.Assert(nullTerminator == 0);
 						instruction.String = Helpers.ShiftJis.GetString(bytes);
 						break;
 
@@ -113,7 +114,8 @@ namespace Majiro.Script {
 
 					case '0':
 						// 4 byte address placeholder
-						Debug.Assert(reader.ReadInt32() == 0);
+						uint addressPlaceholder = reader.ReadUInt32();
+						Debug.Assert(addressPlaceholder == 0);
 						break;
 
 					case 'i':


### PR DESCRIPTION
Moved `ReadByte` and `ReadInt32` outside of `Debug.Assert` methods in `Disassembler.ReadInstruction`. These two were causing failures when reading `.mjo` files in Release mode.

```cs
case 's':
  // string data
  ushort size = reader.ReadUInt16();
  var bytes = reader.ReadBytes(size - 1);
  byte nullTerminator = reader.ReadByte();
  Debug.Assert(nullTerminator == 0); // ReadByte inside would offset expected file position by 1
//...
case '0':
  // 4 byte address placeholder
  uint addressPlaceholder = reader.ReadUInt32();
  Debug.Assert(addressPlaceholder == 0); // ReadInt32 inside would offset expected file position by 4
```

Added missing `using` keyword for `var writer`/`var reader` in `MjProject.Save`/`MjProject.Load` methods. For the `Save` method, this was causing written project files to abruptly end before the remaining text was ever flushed.